### PR TITLE
Remove ACS container locale setting workaround

### DIFF
--- a/docker-compose/alfresco/Dockerfile
+++ b/docker-compose/alfresco/Dockerfile
@@ -1,9 +1,6 @@
 FROM alfresco/alfresco-content-repository-community:6.2.1-A8 
 
 USER root
-# Fix to https://issues.alfresco.com/jira/browse/ALF-22013
-ENV LC_ALL C.UTF-8 \
-    LANG C.UTF-8
 
 ARG TOMCAT_DIR=/usr/local/tomcat
 


### PR DESCRIPTION
This workaround creates some issues due to the fact that locale C.UTF-8 is not present
in base images. And it doesn't seem to be neccesary either as the bug it relates to
is already solved in Alfresco's base java image.